### PR TITLE
Add support for extracting and embedding g-code thumbnails + Bambu/Orca Temp, Time

### DIFF
--- a/gx_converter/header.py
+++ b/gx_converter/header.py
@@ -27,6 +27,11 @@ class Header:
     hotbed_temperature_degrees: int
     extruder_temp_degrees: int
 
+    # optional override for the BMP thumbnail.  When provided, this value will be
+    # used instead of the bundled `thumbnail.bmp`.  It must contain a complete
+    # 24‑bit BMP (80×60) including its 54‑byte header and pixel data.
+    thumbnail_override: bytes | None = None
+
     # byte values
     print_time_bytes: bytes = b""
     filament_usage_bytes: bytes = b""
@@ -51,8 +56,12 @@ class Header:
         )
         self.extruder_temp_bytes: bytes = pack("h", self.extruder_temp_degrees)
 
-        thumbnail = importlib.resources.files("gx_converter").joinpath("thumbnail.bmp")
-        self.thumbnail_bytes = thumbnail.read_bytes()
+        # Select thumbnail: use override if provided, otherwise fall back to bundled BMP.
+        if self.thumbnail_override is not None:
+            self.thumbnail_bytes = self.thumbnail_override
+        else:
+            thumbnail = importlib.resources.files("gx_converter").joinpath("thumbnail.bmp")
+            self.thumbnail_bytes = thumbnail.read_bytes()
         # with open(Path(thumbnail), "rb") as f:
         #     self.thumbnail_bytes = f.read()
 

--- a/gx_converter/main.py
+++ b/gx_converter/main.py
@@ -11,9 +11,53 @@ from .g_code_property_extractor import GCodePropertyExtractor
 from .g_code_transformer import GCodeTransformer
 from .header import Header
 
+import base64
+import re
+from io import BytesIO
+from PIL import Image
+
+
+# -----------------------------------------------------------------------------
+# Thumbnail extraction helper
+def extract_thumbnail_from_gcode(gcode: str) -> bytes | None:
+    """
+    Attempt to extract a thumbnail image embedded in the g-code comments.
+    If found, decode the base64 PNG, resize to 80×60 and save as a 24‑bit BMP.
+    Returns the BMP bytes (including header), or None if no valid thumbnail is found.
+    """
+    match = re.search(
+        r";\s*thumbnail begin\s+(\d+)x(\d+)\s+\d+[\s\n]+([\s\S]*?)\s*;\s*thumbnail end",
+        gcode,
+        re.MULTILINE,
+    )
+    if not match:
+        return None
+    # Strip leading '; ' and concatenate base64 lines
+    b64_data = "".join(line.lstrip("; ").strip() for line in match.group(3).splitlines())
+    try:
+        png_bytes = base64.b64decode(b64_data)
+    except Exception:
+        return None
+    try:
+        with Image.open(BytesIO(png_bytes)) as img:
+            img = img.convert("RGB")
+            # Resize to 80×60 to match .gx requirements
+            img_resized = img.resize((80, 60))
+            buffer = BytesIO()
+            img_resized.save(buffer, format="BMP")
+            bmp = buffer.getvalue()
+            # Ensure correct length (54 header + 80*60*3 pixel bytes = 14454)
+            if len(bmp) != 14454:
+                return None
+            return bmp
+    except Exception:
+        return None
+
 
 def get_parser():
-    parser = argparse.ArgumentParser(description="Convert Cura gcode to .gx format")
+    parser = argparse.ArgumentParser(
+        description="Convert Cura/Bambu/Orca gcode to .gx format"
+    )
     parser.add_argument("gcode", type=str, help="File to convert")
     parser.add_argument(
         "--output",
@@ -48,6 +92,8 @@ def main():
 
     code = GCodeTransformer.convert(code)
 
+    # Try to extract a thumbnail from the original g-code and pass it into Header.
+    thumbnail_bytes = extract_thumbnail_from_gcode(code)
     header = Header(
         print_time,
         filament_usage,
@@ -56,6 +102,7 @@ def main():
         print_speed,
         hotbed_temp,
         nozzle_temp,
+        thumbnail_override=thumbnail_bytes,
     )
 
     gx = header.assembled_header + code.encode("utf-8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ classifiers = [
 ]
 
 requires-python = '>3.9'
+dependencies = [
+    'Pillow',
+]
 
 [project.scripts]
 gx-converter = "gx_converter.main:main"


### PR DESCRIPTION
This update enables extraction of embedded PNG thumbnails from g-code comments, resizes them to 80x60, converts to 24-bit BMP, and embeds them in the .gx file. Also adds support for Bambu/Orca style metadata extraction and updates dependencies to include Pillow for the thumbnail extraction. 

I have a web version also working at https://gxconverter.pages.dev , but that code is not committed here, left in the web folder of my main branch as I don't know if you want to mix code. Thanks for making this! Just wanted to make it work fully with Bambu/Orca with working thumbnails, timing, and temperatures. 